### PR TITLE
ボリューム設定のバグを修正

### DIFF
--- a/client/src/routes/speaker.svelte
+++ b/client/src/routes/speaker.svelte
@@ -69,7 +69,6 @@ async function signIn() {
         const audioBuffer = await ctx.decodeAudioData(buffer);
         const src = ctx.createBufferSource();
         src.buffer = audioBuffer;
-        src.connect(ctx.destination);
         pongs[pongId] = {
           gainNode: ctx.createGain(),
           timestamp,


### PR DESCRIPTION
- 音声ソース → スピーカー
- 音声ソース → ゲイン → スピーカー

の両方の接続が存在していたため、音量調整が無効になっていた（完全に無効ではないが、1.n 倍になる感じ）
前者の接続を削除し、後者だけにすることで、音量調整して鳴らせるようになった（ローカルで確認）。

最小にするとかなり音が小さくなる。
