### PR TITLE
スピーカー画面の初期表示に再生ボタンを追加した

### DIFF
--- a/client/src/routes/speaker.svelte
+++ b/client/src/routes/speaker.svelte
@@ -26,10 +26,10 @@ import { Circle3 } from 'svelte-loading-spinners';
 import { SERVER_URL } from '../pong-swoosh';
 import Slider from 'svelte-slider';
 import { library } from '@fortawesome/fontawesome-svg-core';
-import { faVolumeUp, faVolumeMute } from '@fortawesome/free-solid-svg-icons';
+import { faVolumeUp, faVolumeMute, faPlayCircle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from 'fontawesome-svelte';
 
-library.add(faVolumeUp, faVolumeMute);
+library.add(faVolumeUp, faVolumeMute, faPlayCircle);
 
 type Params = { channelSlug: string };
 export let params: Params;
@@ -95,6 +95,7 @@ let sliderVolume = 1;
 // For Volume
 let isMuted = false;
 let volumeIcon = 'volume-up';
+let canPlay = false;
 
 const onClickMute = () => {
   isMuted = !isMuted;
@@ -108,28 +109,38 @@ const onClickMute = () => {
   })
 }
 
+const onClickCanPlay = () => {
+  canPlay = !canPlay;
+}
+
 </script>
 
 <main>
-  {#await signIn()}
-    <div class="loading">
-      <Circle3
-        size="{size}"
-        unit="{unit}"
-        ballTopLeft="#FF3E00"
-        ballTopRight="#F8B334"
-        ballBottomLeft="#40B3FF"
-        ballBottomRight="#676778" />
+  {#if canPlay === false}
+    <div class="loading" on:click="{onClickCanPlay}">
+      <FontAwesomeIcon icon="play-circle" size="10x"></FontAwesomeIcon>
     </div>
-  {:then value}
-    <h1>スピーカー画面</h1>
-    <div id="volumeup" on:click={onClickMute}>
-      <FontAwesomeIcon icon="{volumeIcon}" size="lg"></FontAwesomeIcon>
-    </div>
-    <div class="slider">
-      <Slider on:change={(event) => sliderVolume = event.detail[1]} value={[0, 1]} single />
-    </div>
-  {:catch error}
-    <h1>接続できませんでした</h1>
-  {/await}
+  {:else}
+    {#await signIn()}
+      <div class="loading">
+        <Circle3
+          size="{size}"
+          unit="{unit}"
+          ballTopLeft="#FF3E00"
+          ballTopRight="#F8B334"
+          ballBottomLeft="#40B3FF"
+          ballBottomRight="#676778" />
+      </div>
+    {:then value}
+      <h1>スピーカー画面</h1>
+      <div id="volumeup" on:click={onClickMute}>
+        <FontAwesomeIcon icon="{volumeIcon}" size="lg"></FontAwesomeIcon>
+      </div>
+      <div class="slider">
+        <Slider on:change={(event) => sliderVolume = event.detail[1]} value={[0, 1]} single />
+      </div>
+    {:catch error}
+      <h1>接続できませんでした</h1>
+    {/await}
+  {/if}
 </main>

--- a/client/src/routes/speaker.svelte
+++ b/client/src/routes/speaker.svelte
@@ -9,6 +9,22 @@ main {
   align-items: center;
   height: 100%;
 }
+.play {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  flex-flow: column;
+}
+.play .icon {
+  color: #FF9800;
+  cursor: pointer;
+  display: block;
+}
+.play label {
+  display: block;
+  margin: 5px;
+}
 .slider {
 	--sliderPrimary: #FF9800;
 	--sliderSecondary: rgba(0, 0, 0, 0.05);
@@ -117,8 +133,11 @@ const onClickCanPlay = () => {
 
 <main>
   {#if canPlay === false}
-    <div class="loading" on:click="{onClickCanPlay}">
-      <FontAwesomeIcon icon="play-circle" size="10x"></FontAwesomeIcon>
+    <div class="play">
+      <div class="icon" on:click={onClickCanPlay}>
+        <FontAwesomeIcon icon="play-circle" size="10x"></FontAwesomeIcon>
+      </div>
+      <label>再生して開始</label>
     </div>
   {:else}
     {#await signIn()}


### PR DESCRIPTION
with #16 
スピーカー画面の初期表示に再生ボタンを追加し、初期処理（signIn）の前に再生ボタンを表示するようにしました

再生ボタンを押したら、初期処理を実行