### PR TITLE
スライダーのライブラリをマテリアルWebComponentsに変更

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,12 +11,12 @@
         "@fingerprintjs/fingerprintjs": "^3.0.5",
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
         "@fortawesome/free-solid-svg-icons": "^5.15.3",
+        "@material/mwc-slider": "^0.21.0",
         "fontawesome-svelte": "^2.0.1",
         "sirv-cli": "^1.0.0",
         "socket.io": "^3.1.1",
         "socket.io-client": "^3.1.1",
-        "svelte-loading-spinners": "^0.1.4",
-        "svelte-slider": "^1.0.0"
+        "svelte-loading-spinners": "^0.1.4"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.0.0",
@@ -155,6 +155,145 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@material/animation": {
+      "version": "8.0.0-canary.01db89053.0",
+      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-8.0.0-canary.01db89053.0.tgz",
+      "integrity": "sha512-PWYCJ7cD2OLO/vRDT1RqXK5cfBTEdCv9sg1c50fPxLptz9jvYc49nP2nnfMefpVkcZoC4lbEOBTDojwffArBdQ==",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@material/animation/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@material/base": {
+      "version": "12.0.0-canary.197f64fa2.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-12.0.0-canary.197f64fa2.0.tgz",
+      "integrity": "sha512-aMPQ4eM95ZQDY53WzcSEbNhZAqRmYzgumpYEdz5PjOKO66lHparMUXlbQ2LqKhMrKuNg/LWY3Ncl8nL0h0LWfA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/dom": {
+      "version": "12.0.0-canary.197f64fa2.0",
+      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-12.0.0-canary.197f64fa2.0.tgz",
+      "integrity": "sha512-uoX4Z0EbrigvHp/M2MzG0S0DNMivTY0U6E0WCiDVo8YrY67NJLSyVJnTpNhtthrCWJInKMcOUJwj73H6/GxX1A==",
+      "dependencies": {
+        "@material/feature-targeting": "12.0.0-canary.197f64fa2.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/feature-targeting": {
+      "version": "12.0.0-canary.197f64fa2.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-12.0.0-canary.197f64fa2.0.tgz",
+      "integrity": "sha512-KZoxPbl0iCsESx11bAZ0qeAQJ7eqI6+nBX0T9AaJ5GFELP168uhkINDJX0TvQf5fgTNkEpeQrncJRaFuqHQTMg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/mwc-base": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-base/-/mwc-base-0.21.0.tgz",
+      "integrity": "sha512-yaXnsgMBtz8NEHLhoA6LNPip/8CWKDOdC6HZAPTBQH+ZnyQ8JvqATGSP0YrkiGg34jNVE8gNrbkI85GzNVKmCA==",
+      "dependencies": {
+        "@material/base": "=12.0.0-canary.197f64fa2.0",
+        "@material/dom": "=12.0.0-canary.197f64fa2.0",
+        "lit-element": "~2.4.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@material/mwc-slider": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-slider/-/mwc-slider-0.21.0.tgz",
+      "integrity": "sha512-VDcYWrYE+vPklY3AWidw38yozCGXl3HDZwH1EttBJIxZSqvh4d5Cci7HvAgRYPEZF+2ODZXOFNBk2k2CkmyDvQ==",
+      "dependencies": {
+        "@material/dom": "=12.0.0-canary.197f64fa2.0",
+        "@material/mwc-base": "^0.21.0",
+        "@material/slider": "=8.0.0-canary.01db89053.0",
+        "lit-element": "~2.4.0",
+        "lit-html": "^1.1.2",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@material/rtl": {
+      "version": "8.0.0-canary.01db89053.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-8.0.0-canary.01db89053.0.tgz",
+      "integrity": "sha512-06DXk4/s3qMTi5Rt8ZoR/aoPiD76q7li10YGBYWnXbwf407FlEloLp/gEuUOsQ5ppju2oFdHAijbRJRzHv4Nug==",
+      "dependencies": {
+        "@material/theme": "8.0.0-canary.01db89053.0"
+      }
+    },
+    "node_modules/@material/slider": {
+      "version": "8.0.0-canary.01db89053.0",
+      "resolved": "https://registry.npmjs.org/@material/slider/-/slider-8.0.0-canary.01db89053.0.tgz",
+      "integrity": "sha512-5+q7WLC24li3iQXUMx0N8DqOLL8aKLk8uiNkKjbQhLeP8VOFE1spd+3y3KKTKzaC1srAb49WLXsXE3sE/sqDVg==",
+      "dependencies": {
+        "@material/animation": "8.0.0-canary.01db89053.0",
+        "@material/base": "8.0.0-canary.01db89053.0",
+        "@material/dom": "8.0.0-canary.01db89053.0",
+        "@material/feature-targeting": "8.0.0-canary.01db89053.0",
+        "@material/rtl": "8.0.0-canary.01db89053.0",
+        "@material/theme": "8.0.0-canary.01db89053.0",
+        "@material/typography": "8.0.0-canary.01db89053.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@material/slider/node_modules/@material/base": {
+      "version": "8.0.0-canary.01db89053.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-8.0.0-canary.01db89053.0.tgz",
+      "integrity": "sha512-KldW1JZ7ZFLKMv/fIqd6CFUbl0TZs/hp6hDjixZe4ctUr8+CK2Nms2Kv2YZbJFfW+fnhWhaEpXs8T+5eeIDQYA==",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@material/slider/node_modules/@material/dom": {
+      "version": "8.0.0-canary.01db89053.0",
+      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-8.0.0-canary.01db89053.0.tgz",
+      "integrity": "sha512-NV2SR1r/cbiyI/pvJMhPUNQwWgFT4eBL+peRnfGvB/X/TwkHJFP3kNJO+0dXTegb4WJMifCxxQR7zb9Ru9jsbw==",
+      "dependencies": {
+        "@material/feature-targeting": "8.0.0-canary.01db89053.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@material/slider/node_modules/@material/feature-targeting": {
+      "version": "8.0.0-canary.01db89053.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-8.0.0-canary.01db89053.0.tgz",
+      "integrity": "sha512-PTTe9rMarEhCHQEuRkqwXvU5Y6Q1saRXCcotS5vcyuhnRoYg9CiiBq1T03mW36KJJBwZvTDXNRbIjtLvFQ2adA=="
+    },
+    "node_modules/@material/slider/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@material/theme": {
+      "version": "8.0.0-canary.01db89053.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-8.0.0-canary.01db89053.0.tgz",
+      "integrity": "sha512-XKk188GWzllx/UfnabIFZa273tYuDjmcHD9oqrsHN1gPKV8cC1n6ynGxPNJkVJI+6CO/5ke9Xqe6MmUCoFoivg==",
+      "dependencies": {
+        "@material/feature-targeting": "8.0.0-canary.01db89053.0"
+      }
+    },
+    "node_modules/@material/theme/node_modules/@material/feature-targeting": {
+      "version": "8.0.0-canary.01db89053.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-8.0.0-canary.01db89053.0.tgz",
+      "integrity": "sha512-PTTe9rMarEhCHQEuRkqwXvU5Y6Q1saRXCcotS5vcyuhnRoYg9CiiBq1T03mW36KJJBwZvTDXNRbIjtLvFQ2adA=="
+    },
+    "node_modules/@material/typography": {
+      "version": "8.0.0-canary.01db89053.0",
+      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-8.0.0-canary.01db89053.0.tgz",
+      "integrity": "sha512-SzlPqvIkToFoisyfkY+Umoxhkl5dr4nNA3CtuBjcYqOsjnUTu0+7iZJWSWdCScGKXnJtVnZjgyTngVqWDGDAZg==",
+      "dependencies": {
+        "@material/feature-targeting": "8.0.0-canary.01db89053.0",
+        "@material/theme": "8.0.0-canary.01db89053.0"
+      }
+    },
+    "node_modules/@material/typography/node_modules/@material/feature-targeting": {
+      "version": "8.0.0-canary.01db89053.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-8.0.0-canary.01db89053.0.tgz",
+      "integrity": "sha512-PTTe9rMarEhCHQEuRkqwXvU5Y6Q1saRXCcotS5vcyuhnRoYg9CiiBq1T03mW36KJJBwZvTDXNRbIjtLvFQ2adA=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.4",
@@ -2128,6 +2267,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lit-element": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.4.0.tgz",
+      "integrity": "sha512-pBGLglxyhq/Prk2H91nA0KByq/hx/wssJBQFiYqXhGDvEnY31PRGYf1RglVzyLeRysu0IHm2K0P196uLLWmwFg==",
+      "dependencies": {
+        "lit-html": "^1.1.1"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
+      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA=="
+    },
     "node_modules/livereload": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/livereload/-/livereload-0.9.1.tgz",
@@ -3350,11 +3502,6 @@
         "node": ">= 9.11.2"
       }
     },
-    "node_modules/svelte-slider": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/svelte-slider/-/svelte-slider-1.0.0.tgz",
-      "integrity": "sha512-299ehVoeS2IUo4THdz84VrrjsnfBLMkzVuI39XxZDUgn/15D5CRLVwWL+p+DM3KlFriAjPjXfhh0FrcTv8XXPQ=="
-    },
     "node_modules/svelte-spa-router": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/svelte-spa-router/-/svelte-spa-router-3.1.0.tgz",
@@ -3700,6 +3847,153 @@
       "integrity": "sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==",
       "requires": {
         "@fortawesome/fontawesome-common-types": "^0.2.35"
+      }
+    },
+    "@material/animation": {
+      "version": "8.0.0-canary.01db89053.0",
+      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-8.0.0-canary.01db89053.0.tgz",
+      "integrity": "sha512-PWYCJ7cD2OLO/vRDT1RqXK5cfBTEdCv9sg1c50fPxLptz9jvYc49nP2nnfMefpVkcZoC4lbEOBTDojwffArBdQ==",
+      "requires": {
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@material/base": {
+      "version": "12.0.0-canary.197f64fa2.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-12.0.0-canary.197f64fa2.0.tgz",
+      "integrity": "sha512-aMPQ4eM95ZQDY53WzcSEbNhZAqRmYzgumpYEdz5PjOKO66lHparMUXlbQ2LqKhMrKuNg/LWY3Ncl8nL0h0LWfA==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "@material/dom": {
+      "version": "12.0.0-canary.197f64fa2.0",
+      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-12.0.0-canary.197f64fa2.0.tgz",
+      "integrity": "sha512-uoX4Z0EbrigvHp/M2MzG0S0DNMivTY0U6E0WCiDVo8YrY67NJLSyVJnTpNhtthrCWJInKMcOUJwj73H6/GxX1A==",
+      "requires": {
+        "@material/feature-targeting": "12.0.0-canary.197f64fa2.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@material/feature-targeting": {
+      "version": "12.0.0-canary.197f64fa2.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-12.0.0-canary.197f64fa2.0.tgz",
+      "integrity": "sha512-KZoxPbl0iCsESx11bAZ0qeAQJ7eqI6+nBX0T9AaJ5GFELP168uhkINDJX0TvQf5fgTNkEpeQrncJRaFuqHQTMg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "@material/mwc-base": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-base/-/mwc-base-0.21.0.tgz",
+      "integrity": "sha512-yaXnsgMBtz8NEHLhoA6LNPip/8CWKDOdC6HZAPTBQH+ZnyQ8JvqATGSP0YrkiGg34jNVE8gNrbkI85GzNVKmCA==",
+      "requires": {
+        "@material/base": "=12.0.0-canary.197f64fa2.0",
+        "@material/dom": "=12.0.0-canary.197f64fa2.0",
+        "lit-element": "~2.4.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "@material/mwc-slider": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-slider/-/mwc-slider-0.21.0.tgz",
+      "integrity": "sha512-VDcYWrYE+vPklY3AWidw38yozCGXl3HDZwH1EttBJIxZSqvh4d5Cci7HvAgRYPEZF+2ODZXOFNBk2k2CkmyDvQ==",
+      "requires": {
+        "@material/dom": "=12.0.0-canary.197f64fa2.0",
+        "@material/mwc-base": "^0.21.0",
+        "@material/slider": "=8.0.0-canary.01db89053.0",
+        "lit-element": "~2.4.0",
+        "lit-html": "^1.1.2",
+        "tslib": "^2.0.1"
+      }
+    },
+    "@material/rtl": {
+      "version": "8.0.0-canary.01db89053.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-8.0.0-canary.01db89053.0.tgz",
+      "integrity": "sha512-06DXk4/s3qMTi5Rt8ZoR/aoPiD76q7li10YGBYWnXbwf407FlEloLp/gEuUOsQ5ppju2oFdHAijbRJRzHv4Nug==",
+      "requires": {
+        "@material/theme": "8.0.0-canary.01db89053.0"
+      }
+    },
+    "@material/slider": {
+      "version": "8.0.0-canary.01db89053.0",
+      "resolved": "https://registry.npmjs.org/@material/slider/-/slider-8.0.0-canary.01db89053.0.tgz",
+      "integrity": "sha512-5+q7WLC24li3iQXUMx0N8DqOLL8aKLk8uiNkKjbQhLeP8VOFE1spd+3y3KKTKzaC1srAb49WLXsXE3sE/sqDVg==",
+      "requires": {
+        "@material/animation": "8.0.0-canary.01db89053.0",
+        "@material/base": "8.0.0-canary.01db89053.0",
+        "@material/dom": "8.0.0-canary.01db89053.0",
+        "@material/feature-targeting": "8.0.0-canary.01db89053.0",
+        "@material/rtl": "8.0.0-canary.01db89053.0",
+        "@material/theme": "8.0.0-canary.01db89053.0",
+        "@material/typography": "8.0.0-canary.01db89053.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@material/base": {
+          "version": "8.0.0-canary.01db89053.0",
+          "resolved": "https://registry.npmjs.org/@material/base/-/base-8.0.0-canary.01db89053.0.tgz",
+          "integrity": "sha512-KldW1JZ7ZFLKMv/fIqd6CFUbl0TZs/hp6hDjixZe4ctUr8+CK2Nms2Kv2YZbJFfW+fnhWhaEpXs8T+5eeIDQYA==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/dom": {
+          "version": "8.0.0-canary.01db89053.0",
+          "resolved": "https://registry.npmjs.org/@material/dom/-/dom-8.0.0-canary.01db89053.0.tgz",
+          "integrity": "sha512-NV2SR1r/cbiyI/pvJMhPUNQwWgFT4eBL+peRnfGvB/X/TwkHJFP3kNJO+0dXTegb4WJMifCxxQR7zb9Ru9jsbw==",
+          "requires": {
+            "@material/feature-targeting": "8.0.0-canary.01db89053.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/feature-targeting": {
+          "version": "8.0.0-canary.01db89053.0",
+          "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-8.0.0-canary.01db89053.0.tgz",
+          "integrity": "sha512-PTTe9rMarEhCHQEuRkqwXvU5Y6Q1saRXCcotS5vcyuhnRoYg9CiiBq1T03mW36KJJBwZvTDXNRbIjtLvFQ2adA=="
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@material/theme": {
+      "version": "8.0.0-canary.01db89053.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-8.0.0-canary.01db89053.0.tgz",
+      "integrity": "sha512-XKk188GWzllx/UfnabIFZa273tYuDjmcHD9oqrsHN1gPKV8cC1n6ynGxPNJkVJI+6CO/5ke9Xqe6MmUCoFoivg==",
+      "requires": {
+        "@material/feature-targeting": "8.0.0-canary.01db89053.0"
+      },
+      "dependencies": {
+        "@material/feature-targeting": {
+          "version": "8.0.0-canary.01db89053.0",
+          "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-8.0.0-canary.01db89053.0.tgz",
+          "integrity": "sha512-PTTe9rMarEhCHQEuRkqwXvU5Y6Q1saRXCcotS5vcyuhnRoYg9CiiBq1T03mW36KJJBwZvTDXNRbIjtLvFQ2adA=="
+        }
+      }
+    },
+    "@material/typography": {
+      "version": "8.0.0-canary.01db89053.0",
+      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-8.0.0-canary.01db89053.0.tgz",
+      "integrity": "sha512-SzlPqvIkToFoisyfkY+Umoxhkl5dr4nNA3CtuBjcYqOsjnUTu0+7iZJWSWdCScGKXnJtVnZjgyTngVqWDGDAZg==",
+      "requires": {
+        "@material/feature-targeting": "8.0.0-canary.01db89053.0",
+        "@material/theme": "8.0.0-canary.01db89053.0"
+      },
+      "dependencies": {
+        "@material/feature-targeting": {
+          "version": "8.0.0-canary.01db89053.0",
+          "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-8.0.0-canary.01db89053.0.tgz",
+          "integrity": "sha512-PTTe9rMarEhCHQEuRkqwXvU5Y6Q1saRXCcotS5vcyuhnRoYg9CiiBq1T03mW36KJJBwZvTDXNRbIjtLvFQ2adA=="
+        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -5329,6 +5623,19 @@
         "type-check": "~0.4.0"
       }
     },
+    "lit-element": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.4.0.tgz",
+      "integrity": "sha512-pBGLglxyhq/Prk2H91nA0KByq/hx/wssJBQFiYqXhGDvEnY31PRGYf1RglVzyLeRysu0IHm2K0P196uLLWmwFg==",
+      "requires": {
+        "lit-html": "^1.1.1"
+      }
+    },
+    "lit-html": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
+      "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA=="
+    },
     "livereload": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/livereload/-/livereload-0.9.1.tgz",
@@ -6297,11 +6604,6 @@
         "detect-indent": "^6.0.0",
         "strip-indent": "^3.0.0"
       }
-    },
-    "svelte-slider": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/svelte-slider/-/svelte-slider-1.0.0.tgz",
-      "integrity": "sha512-299ehVoeS2IUo4THdz84VrrjsnfBLMkzVuI39XxZDUgn/15D5CRLVwWL+p+DM3KlFriAjPjXfhh0FrcTv8XXPQ=="
     },
     "svelte-spa-router": {
       "version": "3.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -44,11 +44,11 @@
     "@fingerprintjs/fingerprintjs": "^3.0.5",
     "@fortawesome/fontawesome-svg-core": "^1.2.35",
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
+    "@material/mwc-slider": "^0.21.0",
     "fontawesome-svelte": "^2.0.1",
     "sirv-cli": "^1.0.0",
     "socket.io": "^3.1.1",
     "socket.io-client": "^3.1.1",
-    "svelte-loading-spinners": "^0.1.4",
-    "svelte-slider": "^1.0.0"
+    "svelte-loading-spinners": "^0.1.4"
   }
 }

--- a/client/src/routes/speaker.svelte
+++ b/client/src/routes/speaker.svelte
@@ -9,13 +9,22 @@ main {
   align-items: center;
   height: 100%;
 }
+.volume {
+  display: flex;
+  justify-content: flex-start;
+}
 .slider {
-	--sliderPrimary: #FF9800;
-	--sliderSecondary: rgba(0, 0, 0, 0.05);
-  margin-left: 30px;
+  margin: 0 10px;
+  flex-grow: 1;
+}
+mwc-slider {
+  --mdc-theme-secondary: #FF9800;
+  --mdc-theme-text-primary-on-dark: #white;
+  width: 100%;
 }
 #volumeup {
-  float: left;
+  display: block;
+  margin: auto 0;
 }
 </style>
 
@@ -24,7 +33,7 @@ import { io } from 'socket.io-client';
 import FingerprintJS from '@fingerprintjs/fingerprintjs';
 import { Circle3 } from 'svelte-loading-spinners';
 import { SERVER_URL } from '../pong-swoosh';
-import Slider from 'svelte-slider';
+import '@material/mwc-slider';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { faVolumeUp, faVolumeMute } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from 'fontawesome-svelte';
@@ -61,10 +70,9 @@ async function signIn() {
     'pongSwoosh',
     async (pongId: string, buffer: ArrayBuffer, volume: number, timestamp: string) => {
       console.log(JSON.stringify({ pongId, volume, timestamp }));
-      const adjustedVolume = volume * sliderVolume;
       if (pongs[pongId] && pongs[pongId].timestamp === timestamp) {
-        pongs[pongId].volume = adjustedVolume;
-        pongs[pongId].gainNode.gain.value = isMuted ? 0 : adjustedVolume;
+        pongs[pongId].volume = volume;
+        pongs[pongId].gainNode.gain.value = isMuted ? 0 : volume * sliderVolume;
       } else {
         window.AudioContext = window.AudioContext || (window as any).webkitAudioContext;
         const ctx = new AudioContext();
@@ -77,8 +85,8 @@ async function signIn() {
         };
         src.connect(pongs[pongId].gainNode);
         pongs[pongId].gainNode.connect(ctx.destination);
-        pongs[pongId].volume = adjustedVolume;
-        pongs[pongId].gainNode.gain.value = isMuted ? 0 : adjustedVolume;
+        pongs[pongId].volume = volume;
+        pongs[pongId].gainNode.gain.value = isMuted ? 0 : volume * sliderVolume;
         src.start();
       }
     },
@@ -91,7 +99,7 @@ async function signIn() {
 let size = '60';
 let unit = 'px';
 // For Slider
-let sliderVolume = 1;
+let sliderVolume = 0.5;
 // For Volume
 let isMuted = false;
 let volumeIcon = 'volume-up';
@@ -104,6 +112,15 @@ const onClickMute = () => {
       pong.gainNode.gain.value = 0
     } else {
       pong.gainNode.gain.value = pong.volume
+    }
+  })
+}
+
+const onChangeVolume = (event) => {
+  sliderVolume = event.target.value / 100;
+  pongs.forEach(pong => {
+    if (!isMuted) {
+      pong.gainNode.gain.value = pong.volume * sliderVolume;
     }
   })
 }
@@ -123,11 +140,13 @@ const onClickMute = () => {
     </div>
   {:then value}
     <h1>スピーカー画面</h1>
-    <div id="volumeup" on:click={onClickMute}>
-      <FontAwesomeIcon icon="{volumeIcon}" size="lg"></FontAwesomeIcon>
-    </div>
-    <div class="slider">
-      <Slider on:change={(event) => sliderVolume = event.detail[1]} value={[0, 1]} single />
+    <div class="volume">
+      <div id="volumeup" on:click={onClickMute}>
+        <FontAwesomeIcon icon="{volumeIcon}" size="lg"></FontAwesomeIcon>
+      </div>
+      <div class="slider">
+        <mwc-slider pin step="1" value="50" min="0" max="100" on:change={onChangeVolume}></mwc-slider>
+      </div>
     </div>
   {:catch error}
     <h1>接続できませんでした</h1>


### PR DESCRIPTION
close #22 

以下のWebComponentsを利用するように変更
https://github.com/material-components/material-components-web-components/tree/master/packages/slider

できること
- 値を変更したときのピン表示（採用）
- 初期値の設定

途中でボリュームが変わったときに追従できるように、pongのvolumeにはサーバーから受信した値を保持し、スライダーの値はgainに設定するとき都度計算するように変更しました。


