### PR TITLE
ボリュームの変化を円弧にしてみた

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -158,7 +158,7 @@ io.on('connection', (socket) => {
         (s) => s.userrole === 'listener'
       ).length;
       debug('LISTENERS', listeners);
-      const volume = (count / listeners) * 2;
+      const volume = Math.sin(Math.PI * 90 * (count / listeners) /180) * 2;
       const timestamp = DateTime.now().toFormat('yyyyMMddHHmmss');
       if (!pong.buffer) {
         const response = await fetch(pong.url);


### PR DESCRIPTION
変更前は直線的にボリュームが変わるけど、変更後は円弧のように変化します。

最小値が0で最大値が2なのは変わらないのですが、たとえば半数の人がリアクションした場合は、これまでだとボリュームは1ですが、これからは 1.414213562373095 になります。

> Math.sin(Math.PI*90*0.5/180)*2 => 1.414213562373095

少人数のリアクションのボリュームの上がり幅が大きく、中間から最大値に近づくにしたがって上がり幅が小さくなる感じですね。

仕様として微妙、とかコメントもいただけると嬉しいです
