### PR TITLE
エントランスページを追加した

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,7 +13,6 @@
         "@fortawesome/free-solid-svg-icons": "^5.15.3",
         "@material/mwc-slider": "^0.21.0",
         "fontawesome-svelte": "^2.0.1",
-        "qs": "^6.10.1",
         "sirv-cli": "^1.0.0",
         "socket.io": "^3.1.1",
         "socket.io-client": "^3.1.1",
@@ -841,6 +840,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -1793,7 +1793,8 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -1805,6 +1806,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -1896,6 +1898,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -1921,6 +1924,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2512,7 +2516,8 @@
     "node_modules/object-inspect": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+      "dev": true
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
@@ -2782,20 +2787,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
-      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/randombytes": {
@@ -3092,19 +3083,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/sirv": {
@@ -4477,6 +4455,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -5269,7 +5248,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -5281,6 +5261,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -5356,6 +5337,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -5374,7 +5356,8 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.8.8",
@@ -5844,7 +5827,8 @@
     "object-inspect": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+      "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
@@ -6049,14 +6033,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
-    },
-    "qs": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
-      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
-      "requires": {
-        "side-channel": "^1.0.4"
-      }
     },
     "randombytes": {
       "version": "2.1.0",
@@ -6293,16 +6269,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
-    },
-    "side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      }
     },
     "sirv": {
       "version": "1.0.11",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16,6 +16,7 @@
         "socket.io": "^3.1.1",
         "socket.io-client": "^3.1.1",
         "svelte-loading-spinners": "^0.1.4",
+        "svelte-qrcode": "^1.0.0",
         "svelte-slider": "^1.0.0"
       },
       "devDependencies": {
@@ -127,7 +128,6 @@
       "version": "0.2.35",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
       "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw==",
-      "hasInstallScript": true,
       "engines": {
         "node": ">=6"
       }
@@ -136,7 +136,6 @@
       "version": "1.2.35",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz",
       "integrity": "sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==",
-      "hasInstallScript": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^0.2.35"
       },
@@ -148,7 +147,6 @@
       "version": "5.15.3",
       "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz",
       "integrity": "sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==",
-      "hasInstallScript": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^0.2.35"
       },
@@ -304,9 +302,10 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.14.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
-      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ=="
+      "version": "15.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
+      "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
+      "dev": true
     },
     "node_modules/@types/pug": {
       "version": "2.0.4",
@@ -1631,10 +1630,7 @@
     "node_modules/fontawesome-svelte": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fontawesome-svelte/-/fontawesome-svelte-2.0.1.tgz",
-      "integrity": "sha512-6OSbpfBFiQA4fcrj5CvJBx36iVYfdvQY8xEdcsQNhWk6FjdwoiWkjxOIvSsr6v1KI2fM9xr99z7uRJHLSsxreQ==",
-      "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "^1.2.26"
-      }
+      "integrity": "sha512-6OSbpfBFiQA4fcrj5CvJBx36iVYfdvQY8xEdcsQNhWk6FjdwoiWkjxOIvSsr6v1KI2fM9xr99z7uRJHLSsxreQ=="
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -3078,6 +3074,11 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/socket.io/node_modules/@types/node": {
+      "version": "14.17.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz",
+      "integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw=="
+    },
     "node_modules/source-map": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
@@ -3349,6 +3350,11 @@
       "engines": {
         "node": ">= 9.11.2"
       }
+    },
+    "node_modules/svelte-qrcode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svelte-qrcode/-/svelte-qrcode-1.0.0.tgz",
+      "integrity": "sha512-WrOvyyxtUzu32gVIDxcFMy0A7uUpbl/8yHaTNOsUaI8W5V4wa7AmReCjffhNY2aS42CqCLJ6qdwUoj/KxmeZzA=="
     },
     "node_modules/svelte-slider": {
       "version": "1.0.0",
@@ -3831,9 +3837,10 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
-      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ=="
+      "version": "15.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
+      "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
+      "dev": true
     },
     "@types/pug": {
       "version": "2.0.4",
@@ -4929,8 +4936,7 @@
     "fontawesome-svelte": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fontawesome-svelte/-/fontawesome-svelte-2.0.1.tgz",
-      "integrity": "sha512-6OSbpfBFiQA4fcrj5CvJBx36iVYfdvQY8xEdcsQNhWk6FjdwoiWkjxOIvSsr6v1KI2fM9xr99z7uRJHLSsxreQ==",
-      "requires": {}
+      "integrity": "sha512-6OSbpfBFiQA4fcrj5CvJBx36iVYfdvQY8xEdcsQNhWk6FjdwoiWkjxOIvSsr6v1KI2fM9xr99z7uRJHLSsxreQ=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -6039,6 +6045,13 @@
         "engine.io": "~4.1.0",
         "socket.io-adapter": "~2.1.0",
         "socket.io-parser": "~4.0.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.17.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz",
+          "integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw=="
+        }
       }
     },
     "socket.io-adapter": {
@@ -6297,6 +6310,11 @@
         "detect-indent": "^6.0.0",
         "strip-indent": "^3.0.0"
       }
+    },
+    "svelte-qrcode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svelte-qrcode/-/svelte-qrcode-1.0.0.tgz",
+      "integrity": "sha512-WrOvyyxtUzu32gVIDxcFMy0A7uUpbl/8yHaTNOsUaI8W5V4wa7AmReCjffhNY2aS42CqCLJ6qdwUoj/KxmeZzA=="
     },
     "svelte-slider": {
       "version": "1.0.0",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
         "@fortawesome/free-solid-svg-icons": "^5.15.3",
         "@material/mwc-slider": "^0.21.0",
         "fontawesome-svelte": "^2.0.1",
+        "qs": "^6.10.1",
         "sirv-cli": "^1.0.0",
         "socket.io": "^3.1.1",
         "socket.io-client": "^3.1.1",
@@ -840,7 +841,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -1793,8 +1793,7 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -1806,7 +1805,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -1898,7 +1896,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -1924,7 +1921,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2516,8 +2512,7 @@
     "node_modules/object-inspect": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-      "dev": true
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
@@ -2787,6 +2782,20 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/randombytes": {
@@ -3083,6 +3092,19 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/sirv": {
@@ -4455,7 +4477,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -5248,8 +5269,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -5261,7 +5281,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -5337,7 +5356,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -5356,8 +5374,7 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "hosted-git-info": {
       "version": "2.8.8",
@@ -5827,8 +5844,7 @@
     "object-inspect": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-      "dev": true
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -6033,6 +6049,14 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "qs": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "randombytes": {
       "version": "2.1.0",
@@ -6269,6 +6293,16 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
     },
     "sirv": {
       "version": "1.0.11",

--- a/client/package.json
+++ b/client/package.json
@@ -49,6 +49,7 @@
     "socket.io": "^3.1.1",
     "socket.io-client": "^3.1.1",
     "svelte-loading-spinners": "^0.1.4",
+    "svelte-qrcode": "^1.0.0",
     "svelte-slider": "^1.0.0"
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -46,7 +46,6 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@material/mwc-slider": "^0.21.0",
     "fontawesome-svelte": "^2.0.1",
-    "qs": "^6.10.1",
     "sirv-cli": "^1.0.0",
     "socket.io": "^3.1.1",
     "socket.io-client": "^3.1.1",

--- a/client/package.json
+++ b/client/package.json
@@ -46,6 +46,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@material/mwc-slider": "^0.21.0",
     "fontawesome-svelte": "^2.0.1",
+    "qs": "^6.10.1",
     "sirv-cli": "^1.0.0",
     "socket.io": "^3.1.1",
     "socket.io-client": "^3.1.1",

--- a/client/src/App.svelte
+++ b/client/src/App.svelte
@@ -7,7 +7,7 @@ import Controller from './routes/controller.svelte';
 
 const routes = {
   '/': Home, // チャンネル作成
-  '/entrance/:channelSlug': Entrance,
+  '/entrance/:channelSlug/:channelName': Entrance,
   '/contoller/:channelSlug': Controller, // コントローラ
   '/speaker/:channelSlug': Speaker, // スピーカー（リスナー）
   //  '*': NotFound,

--- a/client/src/App.svelte
+++ b/client/src/App.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 import Router from 'svelte-spa-router';
 import Home from './routes/home.svelte';
+import Entrance from './routes/entrance.svelte';
 import Speaker from './routes/speaker.svelte';
 import Controller from './routes/controller.svelte';
 
 const routes = {
   '/': Home, // チャンネル作成
+  '/entrance/:channelSlug': Entrance,
   '/contoller/:channelSlug': Controller, // コントローラ
   '/speaker/:channelSlug': Speaker, // スピーカー（リスナー）
   //  '*': NotFound,

--- a/client/src/routes/entrance.svelte
+++ b/client/src/routes/entrance.svelte
@@ -1,0 +1,60 @@
+<style>
+main {
+  text-align: center;
+  padding: 1em;
+  max-width: 240px;
+  margin: 0 auto;
+}
+
+h1 {
+  color: #ff3e00;
+  text-transform: uppercase;
+  font-size: 4em;
+  font-weight: 100;
+}
+
+@media (min-width: 640px) {
+  main {
+    max-width: none;
+  }
+}
+</style>
+
+<script lang="ts">
+
+import QrCode from "svelte-qrcode"
+
+let controllerUrl: string | undefined;
+let speakerUrl: string | undefined;
+
+type Params = { channelSlug: string };
+export let params: Params;
+
+const showEntrance = () => {
+
+  const channelSlug = params.channelSlug;
+  const url = location.origin;
+  controllerUrl = `${url}/#/contoller/${channelSlug}`;
+  speakerUrl = `${url}/#/speaker/${channelSlug}`;
+
+};
+</script>
+
+<main>
+  <h1>ようこそ！</h1>
+  <div>
+    <p>URLからコントローラ画面とスピーカ画面を開いてください。</p>
+    <p>コントローラ画面では音をポン出しできます。<br/>ポン出ししたい音は視聴ボタンで確認できます。</p>
+    <p>スピーカ画面からみんながポン出しした音が再生されます。<br/>環境に合わせてボリュームコントロールで音量を調節してください。</p>
+  </div>
+  <div>
+    <ul>
+      <li>コントローラURL:{controllerUrl}</li>
+      <li>スピーカーURL:{speakerUrl}</li>
+    </ul>
+  </div>
+  <div>
+    <QrCode value={speakerUrl} />
+  </div>
+</main>
+<svelte:window on:load={showEntrance}/>

--- a/client/src/routes/entrance.svelte
+++ b/client/src/routes/entrance.svelte
@@ -24,6 +24,12 @@ h1 {
 
 import QrCode from "svelte-qrcode"
 
+import qs from 'qs'
+import { querystring } from 'svelte-spa-router'
+
+$: parsed = qs.parse($querystring)
+
+let channelName: string | undefined;
 let controllerUrl: string | undefined;
 let speakerUrl: string | undefined;
 
@@ -32,6 +38,7 @@ export let params: Params;
 
 const showEntrance = () => {
 
+  channelName = parsed.name;
   const channelSlug = params.channelSlug;
   const url = location.origin;
   controllerUrl = `${url}/#/contoller/${channelSlug}`;
@@ -41,20 +48,23 @@ const showEntrance = () => {
 </script>
 
 <main>
-  <h1>ようこそ！</h1>
+  <h1>ようこそ！ pong-swooshへ！</h1>
+  <h2>チャンネル名: {channelName}</h2>
   <div>
-    <p>URLからコントローラ画面とスピーカ画面を開いてください。</p>
+    <p>QRコードかURLからコントローラ画面とスピーカ画面を開いてください。</p>
+  </div>
+  <div>
+    <h3>コントローラ画面</h3>
+    <p>URL:{controllerUrl}</p>
+    <QrCode value={controllerUrl} />
     <p>コントローラ画面では音をポン出しできます。<br/>ポン出ししたい音は視聴ボタンで確認できます。</p>
-    <p>スピーカ画面からみんながポン出しした音が再生されます。<br/>環境に合わせてボリュームコントロールで音量を調節してください。</p>
   </div>
+
   <div>
-    <ul>
-      <li>コントローラURL:{controllerUrl}</li>
-      <li>スピーカーURL:{speakerUrl}</li>
-    </ul>
-  </div>
-  <div>
+    <h3>スピーカー画面</h3>
+    <p>URL:{speakerUrl}</p>
     <QrCode value={speakerUrl} />
+    <p>スピーカ画面からみんながポン出しした音が再生されます。<br/>画面のボリュームコントロールで音量を調節してください。</p>
   </div>
 </main>
 <svelte:window on:load={showEntrance}/>

--- a/client/src/routes/entrance.svelte
+++ b/client/src/routes/entrance.svelte
@@ -24,22 +24,17 @@ h1 {
 
 import QrCode from "svelte-qrcode"
 
-import qs from 'qs'
-import { querystring } from 'svelte-spa-router'
-
-$: parsed = qs.parse($querystring)
-
 let channelName: string | undefined;
 let controllerUrl: string | undefined;
 let speakerUrl: string | undefined;
 
-type Params = { channelSlug: string };
+type Params = { channelSlug: string, channelName: string };
 export let params: Params;
 
 const showEntrance = () => {
 
-  channelName = parsed.name;
   const channelSlug = params.channelSlug;
+  channelName = params.channelName;
   const url = location.origin;
   controllerUrl = `${url}/#/contoller/${channelSlug}`;
   speakerUrl = `${url}/#/speaker/${channelSlug}`;

--- a/client/src/routes/home.svelte
+++ b/client/src/routes/home.svelte
@@ -36,6 +36,7 @@ import { SERVER_URL } from '../pong-swoosh';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from 'fontawesome-svelte';
+import qs from 'qs'
 
 library.add(faExclamationTriangle);
 
@@ -54,7 +55,7 @@ const createChannel = async () => {
       return;
     }
     const url = location.href;
-    entranceUrl = `${url}#/entrance/${id}?name=${channelName}`;
+    entranceUrl = `${url}#/entrance/${id}?${qs.stringify({name:channelName})}`;
   });
 };
 

--- a/client/src/routes/home.svelte
+++ b/client/src/routes/home.svelte
@@ -26,8 +26,7 @@ import FingerprintJS from '@fingerprintjs/fingerprintjs';
 import { SERVER_URL } from '../pong-swoosh';
 
 let channelName = '';
-let controllerUrl: string | undefined;
-let speakerUrl: string | undefined;
+let entranceUrl: string | undefined;
 
 const createChannel = async () => {
   const socket = io(SERVER_URL);
@@ -41,10 +40,10 @@ const createChannel = async () => {
       return;
     }
     const url = location.href;
-    controllerUrl = `${url}#/contoller/${id}`;
-    speakerUrl = `${url}#/speaker/${id}`;
+    entranceUrl = `${url}#/entrance/${id}?name=${channelName}`;
   });
 };
+
 </script>
 
 <main>
@@ -54,11 +53,10 @@ const createChannel = async () => {
   <label
     >チャンネル名<input type="text" placeholder="チャンネル名" bind:value="{channelName}" /></label>
   <button on:click="{createChannel}">作成</button>
-  {#if controllerUrl && speakerUrl}
+  {#if entranceUrl}
     <div>
       <ul>
-        <li>コントローラURL:{controllerUrl}</li>
-        <li>スピーカーURL:{speakerUrl}</li>
+        <li>エントランスURL:{entranceUrl}</li>
       </ul>
     </div>
   {/if}

--- a/client/src/routes/home.svelte
+++ b/client/src/routes/home.svelte
@@ -36,7 +36,6 @@ import { SERVER_URL } from '../pong-swoosh';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from 'fontawesome-svelte';
-import qs from 'qs'
 
 library.add(faExclamationTriangle);
 
@@ -55,7 +54,7 @@ const createChannel = async () => {
       return;
     }
     const url = location.href;
-    entranceUrl = `${url}#/entrance/${id}?${qs.stringify({name:channelName})}`;
+    entranceUrl = `${url}#/entrance/${id}/${encodeURIComponent(channelName)}`;
   });
 };
 


### PR DESCRIPTION
close #29 の対応

# やったこと
* エントランスページを追加し、コントローラ画面とスピーカー画面へのURL・QRコードを表示するようにした
* エントランスページっぽく説明を追加してみた
* homeページでチャンネル作成時、エントランスページのurlを表示するように修正した
* チャンネル名はクエリパラメータで渡すようにしてみた。※クエリパラメータの取得方法は下記を参考にしました
https://github.com/ItalyPaleAle/svelte-spa-router/blob/master/Advanced%20Usage.md#querystring-parsing