### PR TITLE
リロードやHeroku再起動時も動作が継続できるようにした

### DIFF
--- a/client/src/routes/controller.svelte
+++ b/client/src/routes/controller.svelte
@@ -91,7 +91,7 @@ library.add(faGamepad, faVolumeUp);
 type Params = { channelSlug: string };
 export let params: Params;
 
-let socket;
+let socket: any;
 let pongs: any[];
 let buttons = {};
 let audios = {};
@@ -109,20 +109,21 @@ async function signIn() {
   const result = await fp.get();
   const visitorId = result.visitorId;
 
+  socket.emit(
+    'connectController',
+    { userId: visitorId, channelId: channelSlug },
+    (err, value) => {
+      if (err) {
+        error(err);
+        return;
+      }
+      pongs = value;
+      done();
+    },
+  );
+
   socket.on('connect', () => {
     console.log('connected', socket.id);
-    socket.emit(
-      'connectController',
-      { userId: visitorId, channelId: channelSlug },
-      (err, value) => {
-        if (err) {
-          error(err);
-          return;
-        }
-        pongs = value;
-        done();
-      },
-    );
   });
 
   socket.on("connect_error", (err) => {
@@ -132,6 +133,7 @@ async function signIn() {
 
   socket.on('disconnect', () => {
     console.log(socket.id); // undefined
+    (document.querySelector('#disconnectFromServer') as any).show();
   });
   return ret;
 }
@@ -182,6 +184,10 @@ let unit = 'px';
             {/each}
           </ul>
         {/if}
+        <mwc-snackbar
+          id="disconnectFromServer"
+          labelText="サーバーから切断されました"
+          timeoutMs="-1"></mwc-snackbar>
       </div>
     </mwc-top-app-bar>
   {:catch error}

--- a/client/src/routes/home.svelte
+++ b/client/src/routes/home.svelte
@@ -128,6 +128,7 @@ library.add(faUsers, faVolumeUp, faShareAlt, faCopy);
 let channelName = '';
 let entranceUrl: string | undefined;
 let socket;
+let channelId: string;
 
 const createChannel = async () => {
   const input = document.querySelector('#channelName') as any;
@@ -149,6 +150,27 @@ const createChannel = async () => {
     }
     const url = location.href;
     entranceUrl = `${url}#/entrance/${id}/${encodeURIComponent(channelName)}`;
+    channelId = id;
+  });
+
+  socket.on('connect', () => {
+    console.log('connected', socket.id);
+    if (entranceUrl) {
+      socket.emit('createChannel', { userId, channelName, channelId }, (err) => {
+        if (err) {
+          console.error('Error reConnect channel', err);
+        }
+        console.log('re connected to channel', channelName);
+      });
+    }
+  });
+
+  socket.on("connect_error", (err) => {
+    console.error(err);
+  });
+
+  socket.on('disconnect', () => {
+    console.log('disconnect');
   });
 };
 

--- a/client/src/routes/speaker.svelte
+++ b/client/src/routes/speaker.svelte
@@ -121,17 +121,18 @@ async function signIn() {
   const result = await fp.get();
   const visitorId = result.visitorId;
 
+  socket.emit('connectListener', { userId: visitorId, channelId: channelSlug },
+    (err) => {
+      if (err) {
+        error(err);
+        return;
+      }
+      done();
+    }
+  );
+
   socket.on('connect', () => {
     console.log('connected', socket.id);
-    socket.emit('connectListener', { userId: visitorId, channelId: channelSlug },
-      (err) => {
-        if (err) {
-          error(err);
-          return;
-        }
-        done();
-      }
-    );
   });
 
   socket.on("connect_error", (err) => {
@@ -141,6 +142,7 @@ async function signIn() {
 
   socket.on('disconnect', () => {
     console.log(socket.id); // undefined
+    (document.querySelector('#disconnectFromServer') as any).show();
   });
 
   socket.on(
@@ -244,6 +246,10 @@ const onClickCanPlay = () => {
               ></mwc-slider>
             </div>
           </div>
+          <mwc-snackbar
+            id="disconnectFromServer"
+            labelText="サーバーから切断されました"
+            timeoutMs="-1"></mwc-snackbar>
         </div>
       {:catch error}
         <div>

--- a/server/create-channel.js
+++ b/server/create-channel.js
@@ -8,17 +8,21 @@ const { v4: uuidv4 } = require('uuid');
  * @param {object} socket - ソケット
  * @param {string} userId - ユーザーID（フィンガープリント）
  * @param {string} channelName -チャンネル名
- * @returns {string} 生成したチャンネルのID
+ * @param {string} channelId - チャンネルID。再接続する場合のみ指定される
+ * @returns {string} 生成したチャンネルのID（再接続のときは指定されたIDがそのまま戻る）
  * @returns {undefined} 生成に失敗したとき
  */
-module.exports = (socket, userId, channelName) => {
-  if (channel.getChannel(userId, channelName)) {
+module.exports = (socket, userId, channelName, channelId) => {
+  const exists = channel.getChannel(userId, channelName);
+  if (exists && !channelId) {
     console.error('#' + channelName + ' exists.');
     return undefined;
   }
-  const channelId = uuidv4();
+  channelId = channelId ? channelId : uuidv4();
 
-  channel.addChannel(userId, channelId, channelName);
+  if (!exists) {
+    channel.addChannel(userId, channelId, channelName);
+  }
 
   socket.join(channelId);
   socket.userrole = 'owner';


### PR DESCRIPTION
close #57 

## やったこと

### コントローラ/スピーカー

- connectイベントを待たずに、クライアント作成イベントを実行する（socket.io v3などでの正しい手順に沿った）
- disconnect されたときに、エラーメッセージを表示するようにした（リロードすれば再接続できる）

### ホーム

- サーバーの接続イベントが来て、すでにエントランスIDが発行されている場合は、一度切断されて再接続されたケースなので、チャンネル再接続イベントを送信する

### サーバー側

- ホーム画面からのチャンネル再接続要求が来たときに、対応する実装に変更