### PR TITLE
幅の狭いスマホでの表示を改善する

### DIFF
--- a/client/src/routes/controller.svelte
+++ b/client/src/routes/controller.svelte
@@ -77,6 +77,16 @@ button label {
   line-height: 2rem;
 }
 
+@media screen and (max-width: 380px) {
+  button {
+    height: 4rem;
+    width: 10rem;
+    position: relative;
+    cursor: pointer;
+    margin: 0.25rem;
+  }
+}
+
 </style>
 
 <script lang="ts">


### PR DESCRIPTION
#82 

以下はiPhone SE幅(360px)での表示確認例
修正前はボタンが縦一列で、すべて表示しきれなかった（スクロールの必要あり）

![localhost_5000_(iPhone SE)](https://user-images.githubusercontent.com/132000/156718355-4aee9efc-3cd1-4ab3-82e7-a880aafd3dda.png)

