### PR TITLE
効果音はクライアント側で読み込むように変更

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2117,9 +2117,9 @@
       }
     },
     "node_modules/engine.io-client": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-4.1.1.tgz",
-      "integrity": "sha512-iYasV/EttP/2pLrdowe9G3zwlNIFhwny8VSIh+vPlMnYZqSzLsTzSLa9hFy015OrH1s4fzoYxeHjVkO8hSFKwg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-4.1.4.tgz",
+      "integrity": "sha512-843fqAdKeUMFqKi1sSjnR11tJ4wi8sIefu6+JC1OzkkJBmjtc/gM/rZ53tJfu5Iae/3gApm5veoS+v+gtT0+Fg==",
       "dependencies": {
         "base64-arraybuffer": "0.1.4",
         "component-emitter": "~1.3.0",
@@ -2129,7 +2129,7 @@
         "parseqs": "0.0.6",
         "parseuri": "0.0.6",
         "ws": "~7.4.2",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "xmlhttprequest-ssl": "~1.6.2",
         "yeast": "0.1.2"
       }
     },
@@ -4826,9 +4826,9 @@
       }
     },
     "node_modules/xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
+      "integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -6795,9 +6795,9 @@
       }
     },
     "engine.io-client": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-4.1.1.tgz",
-      "integrity": "sha512-iYasV/EttP/2pLrdowe9G3zwlNIFhwny8VSIh+vPlMnYZqSzLsTzSLa9hFy015OrH1s4fzoYxeHjVkO8hSFKwg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-4.1.4.tgz",
+      "integrity": "sha512-843fqAdKeUMFqKi1sSjnR11tJ4wi8sIefu6+JC1OzkkJBmjtc/gM/rZ53tJfu5Iae/3gApm5veoS+v+gtT0+Fg==",
       "requires": {
         "base64-arraybuffer": "0.1.4",
         "component-emitter": "~1.3.0",
@@ -6807,7 +6807,7 @@
         "parseqs": "0.0.6",
         "parseuri": "0.0.6",
         "ws": "~7.4.2",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "xmlhttprequest-ssl": "~1.6.2",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -8982,9 +8982,9 @@
       }
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
+      "integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/server/index.js
+++ b/server/index.js
@@ -210,11 +210,7 @@ io.on('connection', (socket) => {
       debug('LISTENERS', listeners);
       const volume = Math.sin((Math.PI * 90 * (count / listeners)) / 180);
       const timestamp = DateTime.now().toFormat('yyyyMMddHHmmss');
-      if (!pong.buffer) {
-        const response = await fetch(pong.url);
-        pong.buffer = await response.arrayBuffer();
-      }
-      io.in(socket.channel).emit('pongSwoosh', event.id, pong.buffer, volume, timestamp);
+      io.in(socket.channel).emit('pongSwoosh', event.id, volume, timestamp);
     } catch (e) {
       console.error('pongSwoosh', e);
     }


### PR DESCRIPTION
## 変更の意図

- サーバーで読み込んで毎回メッセージ送信すると、参加人数が多いとき負荷になる
- 以前はフロントのデプロイ先でなく、別のドメインにあった効果音は、音量調整してホストしたのでクロスドメインでなくなったため、フロントエンドで読み込み可能になった

## 変更概要

- 効果音のメッセージからバッファーを削除（メッセージ引数を変更）
- クライアントは接続時に、効果音一覧の音声をすべてロードする
- スピーカー画面は現時点どこからもリンクされないので、修正対象外（いずれ削除する