### PR TITLE
チェックを変更して、保存する

### DIFF
--- a/client/src/components/pong-buttons.svelte
+++ b/client/src/components/pong-buttons.svelte
@@ -51,9 +51,14 @@ input {
   let audios = {};
   let selects = {};
 
+  export function selectedButtonIds() {
+    return Object.keys(selects).filter((id) => selects[id].checked).map((id) => Number(id));
+  }
+
   const play = (id) => {
     if (socket === undefined) {
-      audios[id].play();
+      const button = pongButtons.find((p) => p.id === id);
+      Object.values<HTMLAudioElement>(audios).find((element) => element.getAttribute('src') === button.url).play();
     } else {
       buttons[id].disabled = true;
       setTimeout(() => (buttons[id].disabled = false), pongButtons.find((p) => p.id === id).duration * 1000);

--- a/client/src/pong-swoosh.ts
+++ b/client/src/pong-swoosh.ts
@@ -1,3 +1,3 @@
 // ローカルで起動する場合は、こちらを有効にする
-// export const SERVER_URL = 'http://localhost:3000';
-export const SERVER_URL = 'https://pong-swoosh-server.herokuapp.com';
+export const SERVER_URL = 'http://localhost:3000';
+// export const SERVER_URL = 'https://pong-swoosh-server.herokuapp.com';

--- a/client/src/pong-swoosh.ts
+++ b/client/src/pong-swoosh.ts
@@ -1,3 +1,3 @@
 // ローカルで起動する場合は、こちらを有効にする
-export const SERVER_URL = 'http://localhost:3000';
-// export const SERVER_URL = 'https://pong-swoosh-server.herokuapp.com';
+// export const SERVER_URL = 'http://localhost:3000';
+export const SERVER_URL = 'https://pong-swoosh-server.herokuapp.com';

--- a/client/src/routes/controller.svelte
+++ b/client/src/routes/controller.svelte
@@ -105,7 +105,7 @@ library.add(faGamepad, faVolumeUp);
 type Params = { channelSlug: string };
 export let params: Params;
 
-let socket: any;
+let socket: ReturnType<typeof io>;
 let pongs: any[];
 let buttons = {};
 

--- a/client/src/routes/home.svelte
+++ b/client/src/routes/home.svelte
@@ -165,6 +165,8 @@ let unit = 'px';
 let allButtons: any[];
 let defaultButtons: any[]
 let isOverSelected = false;
+let selectedButtonIds;
+let selectedButtons = [];
 
 const createChannel = async () => {
   loading = true;
@@ -198,7 +200,7 @@ const createChannel = async () => {
   socket.on('connect', () => {
     console.log('connected', socket.id);
     if (pongSwooshUrl) {
-      socket.emit('createChannel', { userId, channelName, channelId }, (err) => {
+      socket.emit('createChannel', { userId, channelName, channelId, selectedButtons }, (err) => {
         if (err) {
           console.error('Error reConnect channel', err);
         }
@@ -244,6 +246,17 @@ const unload = () => {
 
 const pongCustom = () => {
   document.querySelector<Dialog>('#pong-custom').show();
+  document.querySelector<Dialog>('#pong-custom').addEventListener('closed', (e) => {
+    if ((<CustomEvent>e).detail.action === 'ok') {
+      selectedButtons = selectedButtonIds();
+      socket.emit('saveCustomButtons', { buttonIds: selectedButtons }, (err) => {
+        if (err) {
+          console.error('Error saveCustomButtons', err);
+        }
+      });
+      defaultButtons = allButtons.filter(button => selectedButtons.includes(button.id))
+    }
+  });
 }
 </script>
 
@@ -278,7 +291,7 @@ const pongCustom = () => {
           timeoutMs="4000"></mwc-snackbar>
         <mwc-dialog id="pong-custom">
           {#if allButtons}
-            <PongButtons pongButtons={allButtons} selectable bind:isOverSelected={isOverSelected}></PongButtons>
+            <PongButtons pongButtons={allButtons} selectable bind:isOverSelected={isOverSelected} bind:selectedButtonIds={selectedButtonIds}></PongButtons>
           {/if}
           <mwc-button
               slot="primaryAction"

--- a/server/channel.js
+++ b/server/channel.js
@@ -86,3 +86,43 @@ channel.removeChannel = (userId, channelId, channelsFilePath = DEFAULT_CHANNELS_
   }
   saveChannelsFile(channelsFilePath, channelsList);
 };
+
+/**
+ * チャンネルIDとユーザーIDが一致するチャンネルにカスタムボタン一覧を保存する
+ *
+ * @param {string} userId - ユーザーID
+ * @param {string} channelId - チャンネルID
+ * @param {array} buttonIds - 利用するボタンIDの一覧
+ * @param {string} channelsFilePath - チャンネルファイルパス（指定しない場合は `/channels.json`）
+ */
+channel.updateChannel = (
+  userId,
+  channelId,
+  buttonIds,
+  channelsFilePath = DEFAULT_CHANNELS_FILE_PATH
+) => {
+  const channelsList = require(channelsFilePath);
+  for (let i = 0; i < channelsList.length; i++) {
+    if (channelsList[i].id === channelId && channelsList[i].createdBy === userId) {
+      channelsList[i].buttonIds = buttonIds;
+      break;
+    }
+  }
+  saveChannelsFile(channelsFilePath, channelsList);
+};
+
+/**
+ * チャンネルIDが一致するカスタムボタンID一覧を取得する
+ *
+ * @param {string} channelId - チャンネルID
+ * @returns カスタムボタンID一覧。設定されていない場合は undefined が戻る
+ */
+channel.findCustomButtonIdsById = (channelId, channelsFilePath = DEFAULT_CHANNELS_FILE_PATH) => {
+  const channelsList = require(channelsFilePath);
+  for (let i = 0; i < channelsList.length; i++) {
+    if (channelsList[i].id === channelId) {
+      return channelsList[i].buttonIds;
+    }
+  }
+  return undefined;
+};

--- a/server/channels.json
+++ b/server/channels.json
@@ -1,5 +1,15 @@
 [
     {
         "name": "test"
+    },
+    {
+        "name": "test5",
+        "id": "81108382-421d-4f24-9109-d95ac41ac7c7",
+        "createdBy": "35bb26bffff9b03e899d9c94e303d905"
+    },
+    {
+        "name": "test6",
+        "id": "5d827575-437e-4bb7-92cb-bf9dac3b7f95",
+        "createdBy": "35bb26bffff9b03e899d9c94e303d905"
     }
 ]

--- a/server/channels.json
+++ b/server/channels.json
@@ -1,15 +1,5 @@
 [
     {
         "name": "test"
-    },
-    {
-        "name": "test5",
-        "id": "81108382-421d-4f24-9109-d95ac41ac7c7",
-        "createdBy": "35bb26bffff9b03e899d9c94e303d905"
-    },
-    {
-        "name": "test6",
-        "id": "5d827575-437e-4bb7-92cb-bf9dac3b7f95",
-        "createdBy": "35bb26bffff9b03e899d9c94e303d905"
     }
 ]

--- a/server/index.js
+++ b/server/index.js
@@ -28,93 +28,12 @@ const createChannel = require('./create-channel');
 const closeChannel = require('./close-channel');
 const listChannel = require('./list-channel');
 const joinChannel = require('./join-channel');
+const { updateChannel, findCustomButtonIdsById } = require('./channel');
+const { getAllPongs, getChannelPongs } = require('./pongs');
 
 const pongBaseUrl = ['development', 'test'].includes(process.env.NODE_ENV)
   ? 'http://localhost:5000/pongs'
   : 'https://its-succ.github.io/pong-swoosh/pongs';
-
-const allPongs = [
-  {
-    id: 1,
-    title: '拍手',
-    url: `${pongBaseUrl}/applause.mp3`,
-    icon: `${pongBaseUrl}/applause.svg`,
-    duration: 5,
-    default: true,
-  },
-  {
-    id: 2,
-    title: '納得',
-    url: `${pongBaseUrl}/understand.mp3`,
-    icon: `${pongBaseUrl}/understand.svg`,
-    duration: 2,
-    default: true,
-  },
-  {
-    id: 3,
-    title: '笑い',
-    url: `${pongBaseUrl}/laugh.mp3`,
-    icon: `${pongBaseUrl}/laugh.svg`,
-    duration: 4,
-    default: true,
-  },
-  {
-    id: 4,
-    title: 'えー(驚き)',
-    url: `${pongBaseUrl}/surprise.mp3`,
-    icon: `${pongBaseUrl}/surprise.svg`,
-    duration: 1,
-    default: true,
-  },
-  {
-    id: 5,
-    title: 'おぉ...(感動)',
-    url: `${pongBaseUrl}/wonder.mp3`,
-    icon: `${pongBaseUrl}/wonder.svg`,
-    duration: 2,
-    default: true,
-  },
-  {
-    id: 6,
-    title: 'ドンドンパフパフ',
-    url: `${pongBaseUrl}/dondonpafupafu.mp3`,
-    icon: `${pongBaseUrl}/dondonpafupafu.png`,
-    duration: 2,
-    default: true,
-  },
-  {
-    id: 7,
-    title: 'ドラムロール',
-    url: `${pongBaseUrl}/drum-roll.mp3`,
-    icon: `${pongBaseUrl}/drum-roll.svg`,
-    duration: 4,
-    default: true,
-  },
-  {
-    id: 8,
-    title: 'ドラ',
-    url: `${pongBaseUrl}/gong.mp3`,
-    icon: `${pongBaseUrl}/gong.svg`,
-    duration: 5,
-    default: true,
-  },
-  {
-    id: 9,
-    title: 'へぇー',
-    url: `${pongBaseUrl}/hee.mp3`,
-    icon: `${pongBaseUrl}/hee.svg`,
-    duration: 2,
-    default: false,
-  },
-  {
-    id: 10,
-    title: '見えてます',
-    url: `${pongBaseUrl}/mietemasu.mp3`,
-    icon: `${pongBaseUrl}/mietemasu.svg`,
-    duration: 2,
-    default: false,
-  },
-];
 
 /**
  * チャンネルを削除する
@@ -160,6 +79,15 @@ io.on('connection', (socket) => {
     const err = !created ? Error('Channel can not created.') : undefined;
     callback(err, created);
 
+    if (
+      err === undefined &&
+      event.selectedButtons instanceof Array &&
+      event.selectedButtons.length > 0
+    ) {
+      // 再接続の場合は、イベントにselectedButtonsが指定されてくるので、チャンネルをアップデートする
+      updateChannel(event.userId, created, event.selectedButtons);
+    }
+
     /**
      * チャンネル削除イベント
      *
@@ -174,7 +102,21 @@ io.on('connection', (socket) => {
      * 利用可能なボタン一覧取得イベント
      */
     socket.on('allButtons', async (callback) => {
-      callback(allPongs);
+      callback(getAllPongs(pongBaseUrl));
+    });
+
+    /**
+     * カスタマイズしたボタン一覧を保存するイベント
+     */
+    socket.on('saveCustomButtons', async ({ buttonIds }, callback) => {
+      debug(`saveCustomButtons "${buttonIds}" from ${event.userId}`);
+      try {
+        updateChannel(event.userId, created, buttonIds);
+        if (callback) callback();
+      } catch (e) {
+        console.error('saveCustomButtons', e);
+        if (callback) callback(e);
+      }
     });
 
     /**
@@ -209,7 +151,7 @@ io.on('connection', (socket) => {
     const joined = joinChannel(io, socket, 'controller', event.userId, event.channelId);
     debug('joinChannel', joined);
     const err = !joined ? Error('Channel is not active') : undefined;
-    callback(err, allPongs);
+    callback(err, getChannelPongs(pongBaseUrl, findCustomButtonIdsById(event.channelId)));
     if (!joined) return;
 
     /**
@@ -230,7 +172,7 @@ io.on('connection', (socket) => {
       debug('pongSwoosh', event, socket);
       const count = await redis.incr(`${socket.channel}:${event.id}`);
       debug('COUNT', `${socket.channel}:${event.id}`, count);
-      const pong = allPongs.find((p) => p.id === event.id);
+      const pong = getAllPongs(pongBaseUrl).find((p) => p.id === event.id);
       debug('PONG', pong);
       setTimeout(() => redis.decr(`${socket.channel}:${event.id}`), pong.duration * 1000);
       const listeners = Array.from(io.of('/').in(socket.channel).sockets.values()).filter(
@@ -256,7 +198,9 @@ io.on('connection', (socket) => {
     const joined = joinChannel(io, socket, 'listener', event.userId, event.channelId);
     debug('joinChannel', joined);
     const err = !joined ? Error('Channel is not active') : undefined;
-    if (callback) callback(err, allPongs);
+    if (callback) {
+      callback(err, getChannelPongs(pongBaseUrl, findCustomButtonIdsById(event.channelId)));
+    }
 
     emitLatestParticipants(socket);
 

--- a/server/tests/channel.js
+++ b/server/tests/channel.js
@@ -69,7 +69,7 @@ test('addChannel', () => {
 })(removeChannel);
 
 ((updateChannel) => {
-  test('チャンネルIDとユーザーIDが一致するチャンネルが削除できる', () => {
+  test('チャンネルIDとユーザーIDが一致するチャンネルにカスタムボタンを更新できる', () => {
     updateChannel('user1', '1', [1, 3, 4, 5, 9, 10], channelsFilePath);
     const actual = require(channelsFilePath);
     assert.equal(actual, [{ ...defaultChannels[0], buttonIds: [1, 3, 4, 5, 9, 10] }]);

--- a/server/tests/channel.js
+++ b/server/tests/channel.js
@@ -1,7 +1,14 @@
 const assert = require('uvu/assert');
 const fs = require('fs');
 const tempy = require('tempy');
-const { addChannel, getChannel, listChannel, removeChannel } = require('../channel');
+const {
+  addChannel,
+  getChannel,
+  findCustomButtonIdsById,
+  listChannel,
+  removeChannel,
+  updateChannel,
+} = require('../channel');
 const { test } = require('uvu');
 
 let channelsFilePath;
@@ -60,5 +67,27 @@ test('addChannel', () => {
     assert.equal(actual, []);
   });
 })(removeChannel);
+
+((updateChannel) => {
+  test('チャンネルIDとユーザーIDが一致するチャンネルが削除できる', () => {
+    updateChannel('user1', '1', [1, 3, 4, 5, 9, 10], channelsFilePath);
+    const actual = require(channelsFilePath);
+    assert.equal(actual, [{ ...defaultChannels[0], buttonIds: [1, 3, 4, 5, 9, 10] }]);
+  });
+})(updateChannel);
+
+((findCustomButtonIdsById) => {
+  test('カスタムボタン一覧が設定されていない場合はundefinedになる', () => {
+    const actual = findCustomButtonIdsById('1', channelsFilePath);
+    assert.equal(actual, undefined);
+  });
+
+  test('チャンネルIDが一致するカスタムボタン一覧が取得できる', () => {
+    updateChannel('user1', '1', [1, 3, 4, 5, 9, 10], channelsFilePath);
+    const actual = findCustomButtonIdsById('1', channelsFilePath);
+    assert.equal(actual, [1, 3, 4, 5, 9, 10]);
+  });
+})(findCustomButtonIdsById);
+
 
 test.run();


### PR DESCRIPTION
#3 

## やったこと

- 保存APIを追加
- JSONにチェック状態を保存
- ボタンがカスタマイズされているとき、クライアント接続時に送信するのはカスタマイズされた内容にする

## TODO

- リスナーやコントローラが接続したあとでカスタムされる可能性があるので、変更をブロードキャストする

ここは差分が大きくなりそうだったので、いったんここまでです。

